### PR TITLE
cadastro de novos contratos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,8 @@ model Cliente {
 model Contrato {
   id                 String   @id @default(cuid())
   nomeProjeto        String   // Nome do projeto
+  nomeInterno        String?  // Nome interno do projeto
+  nomeProjetoPai     String?  // Nome do projeto pai
   codigoContrato     String?  // Código do contrato
   clienteId          String   // Cliente de negócio (relacionado ao Cliente)
   clienteSistemaId   String   // Cliente do sistema que possui este contrato

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -51,6 +51,7 @@ interface DespesaAdicional {
 interface Contrato {
   id: string
   nomeProjeto: string
+  nomeProjetoPai?: string
   codigoContrato?: string
   clienteId: string
   dataInicio: string

--- a/src/pages/CadastroContrato.tsx
+++ b/src/pages/CadastroContrato.tsx
@@ -425,7 +425,7 @@ const CadastroContrato = () => {
 
       const contratoData: NovoContrato = {
         nomeProjeto: values.nomeProjeto,
-        nomeProjetoPai: values.nomeProjetoPai || null,
+        // nomeProjetoPai: values.nomeProjetoPai || null, // Temporariamente comentado
         codigoContrato: values.codigoContrato || null,
         clienteId: values.clienteId,
         dataInicio: values.dataInicio?.format('YYYY-MM-DD') || '',
@@ -535,6 +535,7 @@ const CadastroContrato = () => {
                   <Input placeholder="Digite o nome do projeto" />
                 </Form.Item>
 
+                {/* Temporariamente comentado
                 <Form.Item
                   name="nomeProjetoPai"
                   label="Nome Projeto Pai"
@@ -542,6 +543,7 @@ const CadastroContrato = () => {
                 >
                   <Input placeholder="Digite o nome do projeto pai (opcional)" />
                 </Form.Item>
+                */}
 
                 <Form.Item
                   name="codigoContrato"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Temporarily removed the “Parent Project Name” field from the contract form. It’s no longer editable or submitted, though existing records may still display stored values.

- Chores
  - Under-the-hood updates to support optional internal and parent project name attributes for contracts.
  - Extended app data structures to recognize the optional parent project name, with no changes to visible workflows aside from the removed form field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->